### PR TITLE
Feature/species agnostic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,5 +16,5 @@ LazyData: yes
 Date: 2013-04-16
 BuildResaveData: best
 Depends: R (>= 2.10), BiocGenerics
-Imports: S4Vectors, IRanges, GenomicRanges
+Imports: S4Vectors, IRanges, GenomicRanges, hash
 biocViews: aCGH, SNP, CopyNumberVariation, Genetics, Visualization

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.15.0
+Version: 1.16.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.12.0
+Version: 1.13.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.11.0
+Version: 1.12.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.14.0
+Version: 1.15.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.13.0
+Version: 1.14.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: copynumber
 Title: Segmentation of single- and multi-track copy number data by
         penalized least squares regression.
-Version: 1.16.0
+Version: 1.17.0
 Author: Gro Nilsen, Knut Liestoel and Ole Christian Lingjaerde.
 Maintainer: Gro Nilsen <gronilse@ifi.uio.no>
 Description: Penalized least squares regression is applied to fit

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,4 +24,5 @@ import(S4Vectors)
 importFrom(IRanges, IRanges)
 importFrom(GenomicRanges, GRanges)
 importFrom(GenomicRanges, "mcols<-")
+import(hash)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,4 +24,3 @@ import(S4Vectors,hash)
 importFrom(IRanges, IRanges)
 importFrom(GenomicRanges, GRanges)
 importFrom(GenomicRanges, "mcols<-")
-

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,7 +20,9 @@ export(	winsorize,
 		pcfPlain,
 		getGRangesFormat
 		)
-import(S4Vectors,hash)
+import(S4Vectors)
 importFrom(IRanges, IRanges)
 importFrom(GenomicRanges, GRanges)
 importFrom(GenomicRanges, "mcols<-")
+importFrom(hash,hash)
+importFrom(hash,keys)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,9 +20,8 @@ export(	winsorize,
 		pcfPlain,
 		getGRangesFormat
 		)
-import(S4Vectors)
+import(S4Vectors,hash)
 importFrom(IRanges, IRanges)
 importFrom(GenomicRanges, GRanges)
 importFrom(GenomicRanges, "mcols<-")
-import(hash)
 

--- a/R/pcf.r
+++ b/R/pcf.r
@@ -35,7 +35,7 @@ pcf <- function(data,pos.unit="bp",arms=NULL,Y=NULL,kmin=5,gamma=40,normalize=TR
 
   #Check assembly input:
   if(!file.exists(cytoband_file) && !assembly %in% c("hg19","hg18","hg17","hg16","mm7","mm8","mm9")){
-    stop("assembly must be one of hg19, hg18, hg17 or hg16",call.=FALSE)
+    stop("assembly or cytoband file must be provided ( Warning : assembly only works for hg19, hg18, hg17 or hg16 and mm7, mm8, mm9, please provide cytoband for other build/species)",call.=FALSE)
   }  
   #Is data a file:
   isfile.data <- class(data)=="character"

--- a/R/pcf.r
+++ b/R/pcf.r
@@ -106,6 +106,9 @@ pcf <- function(data,pos.unit="bp",arms=NULL,Y=NULL,kmin=5,gamma=40,normalize=TR
 	  	tmpassembly<-read.table(cytoband_file,sep="\t",comment.char = "#",header = FALSE)
 	  }
 	  names(tmpassembly)<-c("chrom","chromStart","chromEnd","name","gieStain")
+	  #restrict assembly to chromosomes in the data frame
+	  tmpassembly<-tmpassembly[tmpassembly$chrom %in% c(keys(tmpChrHash)), ]
+	  tmpassembly<-droplevels(tmpassembly)
 	  for (key in keys(tmpChrHash)) {
      levels(tmpassembly$chrom)[levels(tmpassembly$chrom) == key ] <- tmpChrHash[[key]]
     } 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+##Copynumber with species agnostic pcf
+###This repository is forked from:
+https://github.com/Bioconductor-mirror/copynumber
+
+1. I have made changes to pcf.r function to make it species/build agnostic in following feature branch
+https://github.com/sb43/copynumber/tree/feature/species_agnostic
+
+pcf function now accepts user supplied cytoband file.
+All the chromosomes are now referred by its index values.
+Original chromosomes names were reassigned to index before returning the processed results.
+Same logic can be applied to other functions wherever required.
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-##Copynumber with species agnostic pcf
-###This repository is forked from:
+Copynumber with species agnostic pcf
+====================================
+This repository is forked from:
 https://github.com/Bioconductor-mirror/copynumber
 
-1. I have made changes to pcf.r function to make it species/build agnostic in following feature branch
+I have made changes to pcf.r function to make it species/build agnostic in following feature branch
 https://github.com/sb43/copynumber/tree/feature/species_agnostic
 
 pcf function now accepts user supplied cytoband file.
+
 All the chromosomes are now referred by its index values.
+
 Original chromosomes names were reassigned to index before returning the processed results.
+
 Same logic can be applied to other functions wherever required.
 
 


### PR DESCRIPTION
I have made changes to pcf.r function to make it species/build agnostic in following feature branch https://github.com/sb43/copynumber/tree/feature/species_agnostic

pcf function now accepts user supplied cytoband file.

All the chromosomes are now referred by its index values.

Original chromosomes names were reassigned to index before returning the processed results.

Same logic can be applied to other functions wherever required.